### PR TITLE
Add a script to generate working boot experiments info

### DIFF
--- a/others/boot-experiments/boot_status.py
+++ b/others/boot-experiments/boot_status.py
@@ -26,27 +26,29 @@ tokenize the elements of the list to get the
 working configuration (cpu model, linux version etc.)
 '''
 
-linuxes = ['5.2.3', '4.19.83', '4.14.134', '4.9.186', '4.4.186']
-boot_types = ['init', 'systemd']
-cpu_types = ['kvm', 'atomic', 'simple', 'o3']
-num_cpus = ['1', '2', '4', '8']
-mem_types = ['classic', 'ruby']
 
-name_exists = 0
+def working_status(linux, cpu, mem, num_cpum, boot_type):
+    with open('/fasthome/aakahlow/boot_tests/results/run_exit/vmlinux-{}/boot-exit/{}/{}/{}/{}/info.json'.format(linux, cpu, mem, num_cpu, boot_type)) as f:
+        data = json.load(f)
+        if(data['status'] == 'Finished'):
+            return True
 
 
-working_list = []
+if __name__ == "__main__":
 
-for linux in linuxes:
-    for boot_type in boot_types:
-        for cpu in cpu_types:
-            for num_cpu in num_cpus:
-                for mem in mem_types:
+    linuxes = ['5.2.3', '4.19.83', '4.14.134', '4.9.186', '4.4.186']
+    boot_types = ['init', 'systemd']
+    cpu_types = ['kvm', 'atomic', 'simple', 'o3']
+    num_cpus = ['1', '2', '4', '8']
+    mem_types = ['classic', 'ruby']
 
-                    with open('/fasthome/aakahlow/boot_tests/results/run_exit/vmlinux-{}/boot-exit/{}/{}/{}/{}/info.json'.format(linux, cpu, mem, num_cpu, boot_type)) as f:
-                        data = json.load(f)
-                        if(data['status'] == 'Finished'):
+
+    working_list = []
+
+    for linux in linuxes:
+        for boot_type in boot_types:
+            for cpu in cpu_types:
+                for num_cpu in num_cpus:
+                    for mem in mem_types:
+                        if working_status(linux, cpu, mem, num_cpu, boot_type):
                             working_list.append('{}_{}_{}_{}_{}'.format(cpu,linux,boot_type,mem,num_cpu))
-
-
-


### PR DESCRIPTION
Currently this script gets run objects information from dumped info.json files as the final run objects from boot experiments did not get stored in the database (because of path bug in upload file func).  I will update this script, once I re-run boot experiments 