### PR TITLE
Small script to dump runs of interest in a json file

### DIFF
--- a/others/boot-experiments/runs_data.py
+++ b/others/boot-experiments/runs_data.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import gem5art.run
+import json
+import sys
+
+'''
+Expects an input str = name of the experiments of interest
+Generates a json file containing all the runs from that
+experiment
+'''
+
+if __name__ == "__main__":
+
+    if len(sys.argv) < 2:
+        print('Experiment Name (a string) Expected !!!!')
+        exit()
+    else:
+        inp = str(sys.argv[1])
+
+    jfile = open('runs.json', 'w')
+
+    for i in gem5art.run.getRunsByName(name=inp, fs_only=False, limit=0):
+        d = i._convertForJson(i._getSerializable())
+        json.dump(d, jfile, indent=1)
+


### PR DESCRIPTION
This script takes name of the experiments as input and dumps all the relevant runs in a json file.
This is what I understood from the JIRA ( DARCHR-257) ticket. I can add more features/stuff to this script if needed.
