### PR TITLE
Update install-spec2017.sh

### DIFF
--- a/disk-images/spec2017/install-spec2017.sh
+++ b/disk-images/spec2017/install-spec2017.sh
@@ -14,11 +14,24 @@ rm -f /home/gem5/cpu2017-1.1.0.iso
 # use the example config as the template 
 cp /home/gem5/spec2017/config/Example-gcc-linux-x86.cfg /home/gem5/spec2017/config/myconfig.x86.cfg
 
-# Use sed command to replace the default gcc_dir
+# use sed command to replace the default gcc_dir
 sed -i "s/\/opt\/rh\/devtoolset-7\/root\/usr/\/usr/g" /home/gem5/spec2017/config/myconfig.x86.cfg
 
-# Use sed command to remove the march=native flag when compiling
+# use sed command to remove the march=native flag when compiling
+# this is necessary as the packer script runs in kvm mode, so the details of the CPU will be that of the host CPU
+# the -march=native flag is removed to avoid compiling instructions that gem5 does not support
+# finetuning flags should be manually added
 sed -i "s/-march=native//g" /home/gem5/spec2017/config/myconfig.x86.cfg
+
+# prevent runcpu from calling sysinfo
+# https://www.spec.org/cpu2017/Docs/config.html#sysinfo-program
+# this is necessary as the sysinfo program queries the details of the system's CPU
+# the query causes gem5 runtime error
+sed -i "s/command_add_redirect = 1/sysinfo_program =\ncommand_add_redirect = 1/g" /home/gem5/spec2017/config/myconfig.x86.cfg
 
 # build all SPEC workloads
 runcpu --config=myconfig.x86.cfg --define build_ncpus=$(nproc) --action=build all
+
+# the above building process will produce a large log file
+# this command removes the log files to avoid copying out large files unnecessarily
+rm -f /home/gem5/spec2017/result/*


### PR DESCRIPTION
This fix is necessary for gem5-19.
In short, spec2017 calls `sysinfo` prior to running a workload. `sysinfo` causes gem5-19 to panic. This fix prevents spec2017 from calling `sysinfo`.